### PR TITLE
feat(adapter-configuration): Modified adapter.ts to allow for configu…

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -31,16 +31,13 @@ export default class TypeORMAdapter implements Adapter {
      * @param option typeorm connection option
      */
     public static async newAdapter(option: ConnectionOptions) {
-        const officialOption = {
-            entities: [CasbinRule],
+        const defaults = {
             synchronize: true,
             name: 'node-casbin-official'
         };
-        if (option.name) {
-            officialOption.name = option.name;
-        }
-
-        const a = new TypeORMAdapter(Object.assign(option, officialOption));
+        const entities = { entities: [CasbinRule] };
+        const configuration = Object.assign(defaults, option);
+        const a = new TypeORMAdapter(Object.assign(configuration, entities));
         await a.open();
         return a;
     }


### PR DESCRIPTION
Currently the project enforces default configuration settings that make it inherently unready for production use. Specifically we should not force users to accept `synchronize: true` in their adapter setting. 


This is from the typeORM docs:
> synchronize - Indicates if database schema should be auto created on every application launch. Be careful with this option and don't use this in production - otherwise you can lose production data. This option is useful during debug and development....


