### PR TITLE
Added support for Loading Filtered Policies from DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ async function myFunction() {
     await e.loadPolicy();
 
     // Check the permission.
-    e.enforce('alice', 'data1', 'read');
+    await e.enforce('alice', 'data1', 'read');
 
     // Modify the policy.
     // await e.addPolicy(...);
@@ -100,7 +100,7 @@ async function myFunction() {
     });
 
     // Check the permission.
-    e.enforce('alice', 'data1', 'read');
+    await e.enforce('alice', 'data1', 'read');
 
     // Modify the policy.
     // await e.addPolicy(...);

--- a/README.md
+++ b/README.md
@@ -70,6 +70,46 @@ async function myFunction() {
 }
 ```
 
+## Simple Filter Example
+
+```typescript
+import { newEnforcer } from 'casbin';
+import TypeORMAdapter from 'typeorm-adapter';
+
+async function myFunction() {
+    // Initialize a TypeORM adapter and use it in a Node-Casbin enforcer:
+    // The adapter can not automatically create database.
+    // But the adapter will automatically and use the table named "casbin_rule".
+    // I think ORM should not automatically create databases.  
+    const a = await TypeORMAdapter.newAdapter({
+        type: 'mysql',
+        host: 'localhost',
+        port: 3306,
+        username: 'root',
+        password: '',
+        database: 'casbin',
+    });
+
+
+    const e = await newEnforcer('examples/rbac_model.conf', a);
+
+    // Load the filtered policy from DB.
+    await e.loadFilteredPolicy({
+        'ptype': 'p',
+        'v0': 'alice'
+    });
+
+    // Check the permission.
+    e.enforce('alice', 'data1', 'read');
+
+    // Modify the policy.
+    // await e.addPolicy(...);
+    // await e.removePolicy(...);
+
+    // Save the policy back to DB.
+    await e.savePolicy();
+}
+```
 ## Getting Help
 
 - [Node-Casbin](https://github.com/casbin/node-casbin)

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -16,7 +16,6 @@ import {Adapter, Helper, Model} from 'casbin';
 import {CasbinRule} from './casbinRule';
 import {Connection, ConnectionOptions, createConnection, getRepository, getConnection} from 'typeorm';
 import {CasbinMongoRule} from './casbinMongoRule';
-import { CasbinFilter } from './model';
 
 type GenericCasbinRule = CasbinRule | CasbinMongoRule;
 type CasbinRuleConstructor = new (...args: any[]) => GenericCasbinRule;

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -16,7 +16,7 @@ import {Adapter, Helper, Model} from 'casbin';
 import {CasbinRule} from './casbinRule';
 import {Connection, ConnectionOptions, createConnection, getRepository, getConnection} from 'typeorm';
 import {CasbinMongoRule} from './casbinMongoRule';
-import { CasbinFilter, CasbinRuleFilter } from './model';
+import { CasbinFilter } from './model';
 
 type GenericCasbinRule = CasbinRule | CasbinMongoRule;
 type CasbinRuleConstructor = new (...args: any[]) => GenericCasbinRule;

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -16,6 +16,7 @@ import {Adapter, Helper, Model} from 'casbin';
 import {CasbinRule} from './casbinRule';
 import {Connection, ConnectionOptions, createConnection, getRepository, getConnection} from 'typeorm';
 import {CasbinMongoRule} from './casbinMongoRule';
+import { CasbinFilter, CasbinRuleFilter } from './model';
 
 type GenericCasbinRule = CasbinRule | CasbinMongoRule;
 type CasbinRuleConstructor = new (...args: any[]) => GenericCasbinRule;
@@ -76,6 +77,14 @@ export default class TypeORMAdapter implements Adapter {
         const lines = await getRepository(this.getCasbinRuleConstructor(), this.option.name).find();
 
         for (const line of lines) {
+            this.loadPolicyLine(line, model);
+        }
+    }
+
+    // Loading policies based on filter condition
+    public async loadFilteredPolicy(model: Model, filter: CasbinFilter) {
+        const filteredLines = await getRepository(this.getCasbinRuleConstructor(), this.option.name).find(filter);
+        for (const line of filteredLines) {
             this.loadPolicyLine(line, model);
         }
     }

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -86,7 +86,7 @@ export default class TypeORMAdapter implements Adapter, FilteredAdapter {
     }
 
     // Loading policies based on filter condition
-    public async loadFilteredPolicy(model: Model, filter: any) {
+    public async loadFilteredPolicy(model: Model, filter: object) {
         const filteredLines = await getRepository(this.getCasbinRuleConstructor(), this.option.name).find(filter);
         for (const line of filteredLines) {
             this.loadPolicyLine(line, model);

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -82,7 +82,7 @@ export default class TypeORMAdapter implements Adapter {
     }
 
     // Loading policies based on filter condition
-    public async loadFilteredPolicy(model: Model, filter: CasbinFilter) {
+    public async loadFilteredPolicy(model: Model, filter: object) {
         const filteredLines = await getRepository(this.getCasbinRuleConstructor(), this.option.name).find(filter);
         for (const line of filteredLines) {
             this.loadPolicyLine(line, model);

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Adapter, Helper, Model, FilteredAdapter} from 'casbin';
+import {Helper, Model, FilteredAdapter} from 'casbin';
 import {CasbinRule} from './casbinRule';
 import {Connection, ConnectionOptions, createConnection, getRepository, getConnection} from 'typeorm';
 import {CasbinMongoRule} from './casbinMongoRule';
@@ -21,9 +21,9 @@ type GenericCasbinRule = CasbinRule | CasbinMongoRule;
 type CasbinRuleConstructor = new (...args: any[]) => GenericCasbinRule;
 
 /**
- * TypeORMAdapter represents the TypeORM adapter for policy storage.
+ * TypeORMAdapter represents the TypeORM filtered adapter for policy storage.
  */
-export default class TypeORMAdapter implements Adapter, FilteredAdapter {
+export default class TypeORMAdapter implements FilteredAdapter {
     private option: ConnectionOptions;
     private typeorm: Connection;
     private filtered = false;

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,1 +1,1 @@
-export type CasbinFilter = Record<string, string>;
+export type CasbinFilter = {  }

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,1 +1,0 @@
-export type CasbinFilter = {  }

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,0 +1,1 @@
+export type CasbinFilter = Record<string, string>;

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -125,6 +125,10 @@ test('TestAdapter', async () => {
             ['bob', 'data2', 'write'],
             ['data2_admin', 'data2', 'read'],
             ['data2_admin', 'data2', 'write']]);
+
+        // Load Filtered Policy
+        await a.loadFilteredPolicy(e.getModel(), { ptype : 'p', v0 : 'alice' });
+        testGetPolicy(e, [['alice', 'data1', 'read']]);
     } finally {
         a.close();
     }

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -22,6 +22,11 @@ function testGetPolicy(e: Enforcer, res: string[][]) {
     expect(Util.array2DEquals(res, myRes)).toBe(true);
 }
 
+function testGetFilteredPolicy(e: Enforcer, res: string[]) {
+    const myRes = e.getFilteredNamedPolicy('p', 0, 'alice')[0];
+    expect(Util.arrayEquals(res, myRes)).toBe(true);
+}
+
 test('TestAdapter', async () => {
     const a = await TypeORMAdapter.newAdapter({
         type: 'mysql',
@@ -65,6 +70,10 @@ test('TestAdapter', async () => {
             ['bob', 'data2', 'write'],
             ['data2_admin', 'data2', 'read'],
             ['data2_admin', 'data2', 'write']]);
+
+        // load filtered policies
+        await a.loadFilteredPolicy(e.getModel(), { ptype: 'p', v0: 'alice'});
+        testGetFilteredPolicy(e, ['alice', 'data1', 'read']);
 
         // Add policy to DB
         await a.addPolicy('', 'p', ['role', 'res', 'action']);

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -24,20 +24,12 @@ function testGetPolicy(e: Enforcer, res: string[][]) {
 
 test('TestAdapter', async () => {
     const a = await TypeORMAdapter.newAdapter({
-        // type: 'mysql',
-        // host: 'localhost',
-        // port: 3306,
-        // username: 'root',
-        // password: 'password',
-        // database: 'casbin',
-
         type: 'mysql',
-        host: '192.168.1.5',
+        host: 'localhost',
         port: 3306,
         username: 'root',
-        password: 'password',
+        password: '',
         database: 'casbin',
-        // insecureAuth : true
     });
     try {
         // Because the DB is empty at first,

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -125,13 +125,6 @@ test('TestAdapter', async () => {
             ['bob', 'data2', 'write'],
             ['data2_admin', 'data2', 'read'],
             ['data2_admin', 'data2', 'write']]);
-
-        // Load Filtered Policy
-        /*await a.loadFilteredPolicy(e.getModel(), {
-            ptype: 'p',
-            v0: 'alice'
-        });
-        testGetPolicy(e, [['alice', 'data1', 'read']]);*/
     } finally {
         a.close();
     }

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -37,7 +37,7 @@ test('TestAdapter', async () => {
         username: 'root',
         password: 'password',
         database: 'casbin',
-        //insecureAuth : true
+        // insecureAuth : true
     });
     try {
         // Because the DB is empty at first,
@@ -135,8 +135,8 @@ test('TestAdapter', async () => {
             ['data2_admin', 'data2', 'write']]);
 
         // Load Filtered Policy
-        //await e.loadFilteredPolicy({ ptype : 'p', v0 : 'alice'  });
-        //testGetPolicy(e, [['alice', 'data1', 'read']]);
+        // await e.loadFilteredPolicy({ ptype : 'p', v0 : 'alice'  });
+        // testGetPolicy(e, [['alice', 'data1', 'read']]);
     } finally {
         a.close();
     }

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -24,12 +24,20 @@ function testGetPolicy(e: Enforcer, res: string[][]) {
 
 test('TestAdapter', async () => {
     const a = await TypeORMAdapter.newAdapter({
+        // type: 'mysql',
+        // host: 'localhost',
+        // port: 3306,
+        // username: 'root',
+        // password: 'password',
+        // database: 'casbin',
+
         type: 'mysql',
-        host: 'localhost',
+        host: '192.168.1.5',
         port: 3306,
         username: 'root',
-        password: '',
+        password: 'password',
         database: 'casbin',
+        //insecureAuth : true
     });
     try {
         // Because the DB is empty at first,
@@ -127,8 +135,8 @@ test('TestAdapter', async () => {
             ['data2_admin', 'data2', 'write']]);
 
         // Load Filtered Policy
-        await a.loadFilteredPolicy(e.getModel(), { ptype : 'p', v0 : 'alice' });
-        testGetPolicy(e, [['alice', 'data1', 'read']]);
+        //await e.loadFilteredPolicy({ ptype : 'p', v0 : 'alice'  });
+        //testGetPolicy(e, [['alice', 'data1', 'read']]);
     } finally {
         a.close();
     }

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -25,10 +25,10 @@ function testGetPolicy(e: Enforcer, res: string[][]) {
 test('TestAdapter', async () => {
     const a = await TypeORMAdapter.newAdapter({
         type: 'mysql',
-        host: '192.168.1.5',
+        host: 'localhost',
         port: 3306,
         username: 'root',
-        password: 'password',
+        password: '',
         database: 'casbin',
     });
     try {

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -25,10 +25,10 @@ function testGetPolicy(e: Enforcer, res: string[][]) {
 test('TestAdapter', async () => {
     const a = await TypeORMAdapter.newAdapter({
         type: 'mysql',
-        host: 'localhost',
+        host: '192.168.1.5',
         port: 3306,
         username: 'root',
-        password: '',
+        password: 'password',
         database: 'casbin',
     });
     try {
@@ -127,8 +127,11 @@ test('TestAdapter', async () => {
             ['data2_admin', 'data2', 'write']]);
 
         // Load Filtered Policy
-        // await e.loadFilteredPolicy({ ptype : 'p', v0 : 'alice'  });
-        // testGetPolicy(e, [['alice', 'data1', 'read']]);
+        /*await a.loadFilteredPolicy(e.getModel(), {
+            ptype: 'p',
+            v0: 'alice'
+        });
+        testGetPolicy(e, [['alice', 'data1', 'read']]);*/
     } finally {
         a.close();
     }


### PR DESCRIPTION
Hi,

I have coded a new method called loadFilteredPolicy() to load filtered policies from a given entity repo based on filtered object passed to it.
We are using TypeORM Adapter for Casbin in our project and this is an urgent requirement for us to have this missing functionality so I have added in it and raised PR.

Kindly assist to review my PR and approve it.

Thank you,
Vinod Kumar